### PR TITLE
Changed handling of invalid characters in game title

### DIFF
--- a/reScreeny.c
+++ b/reScreeny.c
@@ -92,7 +92,10 @@ void sanitize(char *in, int len) {
 		int i = 0;
 		while(il_chars[i]!=0) {
 			if(*ptr==il_chars[i]) {
-				*ptr = ' ';
+				if(ptr==in + len - 1)
+					*ptr = 0;
+				else
+					*ptr = ' ';
 				break;
 			}
 			i++;

--- a/reScreeny.c
+++ b/reScreeny.c
@@ -88,19 +88,43 @@ void sanitize(char *in, int len) {
 	char il_chars[] = "<>:/\"\\|?*\n";
 	
 	char *ptr = in;
-	while(ptr < in + len) {
+	
+	// sanitize start
+	while (ptr < in + len) {
+		int i = 0, found = 0;
+		while (il_chars[i] != 0) {
+			if ((*ptr == il_chars[i]) || (*ptr == ' ')) {
+				char *ptr2 = ptr;
+				while (*ptr2 != 0) {
+					*ptr2 = *(ptr2 + 1);
+					ptr2++;
+				}
+				found = 1;
+				break;
+			}
+			i++;
+		}
+		if (!found) break;
+	}
+	
+	// sanitize rest
+	while (ptr < in + len) {
 		int i = 0;
-		while(il_chars[i]!=0) {
-			if(*ptr==il_chars[i]) {
-				if(ptr==in + len - 1)
-					*ptr = 0;
-				else
-					*ptr = ' ';
+		while (il_chars[i] != 0) {
+			if (*ptr == il_chars[i]) {
+				*ptr = ' ';
 				break;
 			}
 			i++;
 		}
 		ptr++;
+	}
+	
+	// fixup end
+	while (ptr > in) {
+		if (*ptr != ' ' && *ptr != 0) break;
+		*ptr = 0;
+		ptr--;
 	}
 }
 


### PR DESCRIPTION
This PR changes how an invalid character as the final character in a game's title is handled; it is now changed to a null byte instead of a space.

This works around an issue where ex. transferring screenshots from the Vita to a Windows PC via FTP would cause the FTP client and/or OS to produce "file not found" errors and the like, due to not handling whitespaces at the beginning or end of file/folder names well. Superdimension Neptune VS Sega Hard Girls is one game that causes this.

Do note this is a just partial bandaid kinda fix, as ideally, not only the final character in the title should be checked and nulled, but all illegal characters in the beginning and end should be stripped out completely.